### PR TITLE
Fix cannot import name 'prepare_model_for_int8_training' from 'peft'

### DIFF
--- a/src/model/graph_llm.py
+++ b/src/model/graph_llm.py
@@ -8,7 +8,8 @@ from src.model.gnn import load_gnn_model
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    # prepare_model_for_int8_training,
+    prepare_model_for_kbit_training
 )
 
 BOS = '<s>[INST]'
@@ -53,7 +54,8 @@ class GraphLLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            # model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
             lora_r: int = 8
             lora_alpha: int = 16
             lora_dropout: float = 0.05

--- a/src/model/llm.py
+++ b/src/model/llm.py
@@ -5,7 +5,8 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    #prepare_model_for_int8_training,
+    prepare_model_for_kbit_training
 )
 
 BOS = '<s>[INST]'
@@ -49,7 +50,8 @@ class LLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            # model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
 
             lora_r: int = 8
             lora_alpha: int = 16

--- a/src/model/pt_llm.py
+++ b/src/model/pt_llm.py
@@ -6,7 +6,8 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    # prepare_model_for_int8_training,
+    prepare_model_for_kbit_training
 )
 
 BOS = '<s>[INST]'
@@ -52,7 +53,8 @@ class PromptTuningLLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            # model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
 
             lora_r: int = 8
             lora_alpha: int = 16


### PR DESCRIPTION
Fix for the following error:

Traceback (most recent call last):
  File "/sensei-fs/users/krishnag/G-Retriever/inference.py", line 11, in <module>
    from src.model import load_model, llama_model_path
  File "/sensei-fs/users/krishnag/G-Retriever/src/model/__init__.py", line 1, in <module>
    from src.model.llm import LLM
  File "/sensei-fs/users/krishnag/G-Retriever/src/model/llm.py", line 5, in <module>
    from peft import (
ImportError: cannot import name 'prepare_model_for_int8_training' from 'peft' (/home/krishnag/sensei-fs-link/anaconda3/envs/g_retriever/lib/python3.9/site-packages/peft/__init__.py)


References:
1. https://github.com/huggingface/peft/issues/1583
2. https://github.com/huggingface/peft/issues/108