### PR TITLE
Add configuration to set the memory size

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,10 @@ docs/_build/
 
 # dataset
 #dataset/
+dataset/**/[0-9]*.csv
+dataset/**/*.pt
+dataset/gqa/val_sceneGraphs.json
+dataset/gqa/train_sceneGraphs.json
 
 # logs and results
 logs/

--- a/README.md
+++ b/README.md
@@ -44,7 +44,8 @@ pip install sentencepiece
 pip install torch_geometric
 pip install datasets
 pip install pcst_fast
-
+pip install gensim
+pip install scipy=1.12
 ```
 
 ## Data Preprocessing

--- a/src/config.py
+++ b/src/config.py
@@ -1,5 +1,7 @@
 import argparse
 
+def csv_list(string):
+    return string.split(',')
 
 def parse_args_llama():
     parser = argparse.ArgumentParser(description="G-Retriever")
@@ -32,6 +34,7 @@ def parse_args_llama():
     parser.add_argument("--output_dir", type=str, default='output')
     parser.add_argument("--max_txt_len", type=int, default=512)
     parser.add_argument("--max_new_tokens", type=int, default=32)
+    parser.add_argument("--max_memory", type=csv_list, default=[80,80])
 
     # GNN related
     parser.add_argument("--gnn_model_name", type=str, default='gat')

--- a/src/model/__init__.py
+++ b/src/model/__init__.py
@@ -12,8 +12,8 @@ load_model = {
 
 # Replace the following with the model paths
 llama_model_path = {
-    '7b': 'llama2/llama2_7b_hf',
-    '13b': 'llama2/llama2_13b_hf',
-    '7b_chat': 'llama2/llama2_7b_chat_hf',
-    '13b_chat': 'llama2/llama2_13b_chat_hf',
+    '7b': 'meta-llama/Llama-2-7b-hf',
+    '13b': 'meta-llama/Llama-2-13b-hf',
+    '7b_chat': 'meta-llama/Llama-2-7b-chat-hf',
+    '13b_chat': 'meta-llama/Llama-2-13b-chat-hf',
 }

--- a/src/model/graph_llm.py
+++ b/src/model/graph_llm.py
@@ -8,7 +8,7 @@ from src.model.gnn import load_gnn_model
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
 )
 
 BOS = '<s>[INST]'
@@ -53,7 +53,7 @@ class GraphLLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
             lora_r: int = 8
             lora_alpha: int = 16
             lora_dropout: float = 0.05

--- a/src/model/llm.py
+++ b/src/model/llm.py
@@ -5,7 +5,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
 )
 
 BOS = '<s>[INST]'
@@ -28,7 +28,7 @@ class LLM(torch.nn.Module):
 
         print('Loading LLAMA')
         kwargs = {
-            "max_memory": {0: '80GiB', 1: '80GiB'},
+            "max_memory": {i: f'{size}GiB' for i, size in enumerate(args.max_memory)},
             "device_map": "auto",
             "revision": "main",
         }
@@ -49,7 +49,7 @@ class LLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
 
             lora_r: int = 8
             lora_alpha: int = 16

--- a/src/model/pt_llm.py
+++ b/src/model/pt_llm.py
@@ -6,7 +6,7 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from peft import (
     LoraConfig,
     get_peft_model,
-    prepare_model_for_int8_training,
+    prepare_model_for_kbit_training,
 )
 
 BOS = '<s>[INST]'
@@ -52,7 +52,7 @@ class PromptTuningLLM(torch.nn.Module):
                 param.requires_grad = False
         else:
             print("Training LLAMA with LORA!")
-            model = prepare_model_for_int8_training(model)
+            model = prepare_model_for_kbit_training(model)
 
             lora_r: int = 8
             lora_alpha: int = 16


### PR DESCRIPTION
Thanks for this great work, @XiaoxinHe!

This PR is adding a new `--max-memory` parameter with which one can specify the GPU memory to be used. With this change, it makes it possible to run it on a smaller env (with a single GPU, for instace).

The `--max-memory` parameter is a comma separated list and its default value is `80,80`.

This PR is also duing some other small changes:
- Adding indirect dependencies that needed to be added in my env to get it working.
- Removing some commented code related to `prepare_model_for_int8_training`.
- Add some generated files to the `.gitignore`.